### PR TITLE
Update 03-typecastExample.cpp

### DIFF
--- a/03-typecastExample.cpp
+++ b/03-typecastExample.cpp
@@ -1,5 +1,6 @@
 // Explicit type casting example
 #include <iostream>
+#include <iomanip>
 #include <conio.h> // for getch
 
 using namespace std;
@@ -11,7 +12,7 @@ int main()
 
     cout << "intvar = " << intvar << endl;
     cout << "floatvar = " << floatvar << endl;
-    cout << " float(intvar) %.2f= " << float(intvar) << endl;
+    cout << "float(intvar) = " << fixed << setprecision(2) << float(intvar) << endl;
     cout << "int(floatvar) = " << int(floatvar) << endl;
 
     getch();


### PR DESCRIPTION
Hi Professor Melanahalli,

When printing the value for the `float(intvar)` casting, the `%.2f` formatting did not work for me. Instead, I used the `<iomanip>` library to properly format to two decimal places.
```
#include <iomanip>
...
cout << "float(intvar) = " << fixed << setprecision(2) << float(intvar) << endl;
```
Best,
Matt